### PR TITLE
Package and package.json caching

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+0.5.0 / 2016-10-17
+==================
+
+  * integrated [clib-cache](https://github.com/clibs/clib-cache) for package, and package.json caching
+  * added `clib_package_opts_t` for easier configuration
 
 0.4.2 / 2016-01-17
 ==================

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VALGRIND ?= valgrind
 TEST_RUNNER ?=
 
 SRC = $(wildcard src/*.c)
-DEPS += $(wildcard deps/*/*.c)
+DEPS += $(filter-out deps/clib-package/clib-package.c, $(wildcard deps/*/*.c))
 OBJS = $(SRC:.c=.o) $(DEPS:.c=.o)
 TEST_SRC = $(wildcard test/*.c)
 TEST_OBJ = $(TEST_SRC:.c=.o)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "strdup": "0.0.0",
     "stephenmathieson/parse-repo.c": "1.1.1",
     "logger": "0.0.1",
-    "stephenmathieson/debug.c": "0.0.0"
+    "stephenmathieson/debug.c": "0.0.0",
+    "clib-cache": "0.0.0"
   },
   "development": {
     "stephenmathieson/describe.h": "2.0.1",

--- a/src/clib-package.c
+++ b/src/clib-package.c
@@ -226,6 +226,10 @@ install_packages(list_t *list, const char *dir, int verbose) {
 
     dep = (clib_package_dependency_t *) node->val;
     slug = clib_package_slug(dep->author, dep->name, dep->version);
+    if (0 == strcmp(dep->name, "clib-package")){
+        free(slug);
+        continue;
+    }
     if (NULL == slug) goto loop_cleanup;
 
     pkg = clib_package_new_from_slug(slug, verbose);

--- a/src/clib-package.c
+++ b/src/clib-package.c
@@ -226,10 +226,6 @@ install_packages(list_t *list, const char *dir, int verbose) {
 
     dep = (clib_package_dependency_t *) node->val;
     slug = clib_package_slug(dep->author, dep->name, dep->version);
-    if (0 == strcmp(dep->name, "clib-package")){
-        free(slug);
-        continue;
-    }
     if (NULL == slug) goto loop_cleanup;
 
     pkg = clib_package_new_from_slug(slug, verbose);

--- a/src/clib-package.h
+++ b/src/clib-package.h
@@ -34,6 +34,15 @@ typedef struct {
   list_t *src;
 } clib_package_t;
 
+typedef struct
+{
+    int skip_cache;
+} clib_package_opts_t;
+
+
+void
+clib_package_set_opts(clib_package_opts_t opts);
+
 clib_package_t *
 clib_package_new(const char *, int);
 


### PR DESCRIPTION
This PR integrates the functionality of [clib-cache](https://github.com/clibs/clib-cache), for better performance. 

Package.json files, and the packages are cached after fetching (each version separately). If the `skip_cache = 1` option is passed through `clib_package_set_opts` the cache will be removed if exists, and saved again, basically updates it. 

The cache stored in ~./cache/clib, on Windows it should be in AppData, unfortunately I can't test it, it'd be appreciated if someone could.


Example with installing `clib-cache` dependencies

When nothing is cached:
```
$ time clib install

fetch : Isty001/copy:src/copy.h
save : ./deps/copy/copy.h
fetch : cxong/tinydir:package.json
.....
```
result: clib install  1.98s user 0.11s system 7% cpu **27.077 total**


When everything is cached:

```
$ time clib install

cache : isty001/copy:package.json
cache : Isty001/copy
cache : cxong/tinydir:package.json
...
```
result: clib install  0.01s user 0.04s system 10% cpu **0.479 total**

If this is merged, I'll be able to open the PR to `clib` itself.

Known issue: `clib-package` and `clib-cache` has a circular dependency, thus the hackish filter in the Makefile.