### PR TITLE
Decouple clib-cache from clib-package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clib-package",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "repo": "clibs/clib-package",
   "src": [
     "src/clib-package.h",
@@ -18,7 +18,7 @@
     "stephenmathieson/parse-repo.c": "1.1.1",
     "logger": "0.0.1",
     "stephenmathieson/debug.c": "0.0.0",
-    "clib-cache": "0.0.0"
+    "clib-cache": "0.1.0"
   },
   "development": {
     "stephenmathieson/describe.h": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,7 @@
     "stephenmathieson/parse-repo.c": "1.1.1",
     "logger": "0.0.1",
     "stephenmathieson/debug.c": "0.0.0",
-<<<<<<< HEAD
     "clib-cache": "0.1.0"
-=======
-    "clib-cache": "0.0.0"
->>>>>>> 25e33ce316bcd009d3e3fb95420fe4cb008b5f9c
   },
   "development": {
     "stephenmathieson/describe.h": "2.0.1",

--- a/src/clib-package.c
+++ b/src/clib-package.c
@@ -664,12 +664,12 @@ clib_package_install(clib_package_t *pkg, const char *dir, int verbose) {
   // if no sources are listed, just install
   if (NULL == pkg->src) goto install;
 
-  if (clib_cache_has_package(pkg)) {
+  if (clib_cache_has_package(pkg->author, pkg->name, pkg->version)) {
     if (opts.skip_cache){
-        clib_cache_delete_package(pkg);
+        clib_cache_delete_package(pkg->author, pkg->name, pkg->version);
         goto download;
     }
-    if (0 != clib_cache_load_package(pkg, pkg_dir)){
+    if (0 != clib_cache_load_package(pkg->author, pkg->name, pkg->version, pkg_dir)){
       goto download;
     }
     logger_info("cache", pkg->repo);
@@ -687,7 +687,7 @@ clib_package_install(clib_package_t *pkg, const char *dir, int verbose) {
         goto cleanup;
       }
     }
-    clib_cache_save_package(pkg, pkg_dir);
+    clib_cache_save_package(pkg->author, pkg->name, pkg->version, pkg_dir);
 
 install:
   rc = clib_package_install_dependencies(pkg, dir, verbose);

--- a/test/package-install.c
+++ b/test/package-install.c
@@ -1,4 +1,5 @@
 
+#include <clib-package.h>
 #include "describe/describe.h"
 #include "rimraf/rimraf.h"
 #include "fs/fs.h"
@@ -65,7 +66,7 @@ main() {
     }
 
     it("should install itself") {
-      clib_package_t *pkg = clib_package_new_from_slug("stephenmathieson/clib-package", 0);
+      clib_package_t *pkg = clib_package_new_from_slug("stephenmathieson/clib-package@0.4.2", 0);
       assert(pkg);
       assert(0 == clib_package_install(pkg, "./test/fixtures/", 0));
       assert(0 == fs_exists("./test/fixtures/"));


### PR DESCRIPTION
As @stephenmathieson said, [#146](https://github.com/clibs/clib/pull/146) is a bit messy, so for the first step, let's just integrate the cache. This can't be done without removing the cross dependency, because `clib install` will stuck in an infinite loop. 

If this is merged, I'll update [#146](https://github.com/clibs/clib/pull/146) with the necessary changes, instead of it's current form. 